### PR TITLE
DM-47262: Bump Python version for Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 #   - Runs a non-root user.
 #   - Sets up the entrypoint and port.
 
-FROM python:3.12.5-slim-bookworm AS base-image
+FROM python:3.12.7-slim-bookworm AS base-image
 
 # Update system packages.
 COPY scripts/install-base-packages.sh .


### PR DESCRIPTION
Increase the version of the base Python image to the latest patch release of Python 3.12. We're not quite ready to go to Python 3.13 yet.