### PR TITLE
DM-47262: Add an admin API

### DIFF
--- a/src/wobbly/handlers/admin.py
+++ b/src/wobbly/handlers/admin.py
@@ -23,7 +23,7 @@ router = APIRouter()
 
 
 @router.get(
-    "/services",
+    "/admin/services",
     description="List services with at least one job stored",
     response_model=list[str],
     summary="List services",
@@ -38,7 +38,7 @@ async def list_services(
 
 
 @router.get(
-    "/services/{service}/users",
+    "/admin/services/{service}/users",
     description="List users with at least one job stored",
     response_model=list[str],
     summary="List users",
@@ -54,7 +54,7 @@ async def list_users(
 
 
 @router.get(
-    "/services/{service}/users/{user}/jobs",
+    "/admin/services/{service}/users/{user}/jobs",
     description="List jobs for a user and service",
     response_model=list[Job],
     response_model_exclude_defaults=True,
@@ -95,7 +95,7 @@ async def list_jobs(
 
 
 @router.get(
-    "/services/{service}/users/{user}/jobs/{job_id}",
+    "/admin/services/{service}/users/{user}/jobs/{job_id}",
     description="Retrieve the record for a single job",
     response_model=Job,
     response_model_exclude_defaults=True,

--- a/src/wobbly/handlers/admin.py
+++ b/src/wobbly/handlers/admin.py
@@ -1,0 +1,118 @@
+"""Administrative routes.
+
+These routes allow read-only access to job records for any service and user.
+Write or delete access may be added later if needed. They should be protected
+by an admin-only ``GafaelfawrIngress``.
+"""
+
+from datetime import datetime
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Query
+from safir.models import ErrorLocation
+from vo_models.uws.types import ExecutionPhase
+
+from ..dependencies.context import RequestContext, context_dependency
+from ..exceptions import UnknownJobError
+from ..models import Job, JobIdentifier
+
+__all__ = ["router"]
+
+router = APIRouter()
+"""FastAPI router for all admin handlers."""
+
+
+@router.get(
+    "/services",
+    description="List services with at least one job stored",
+    response_model=list[str],
+    summary="List services",
+    tags=["admin"],
+)
+async def list_services(
+    *,
+    context: Annotated[RequestContext, Depends(context_dependency)],
+) -> list[str]:
+    job_service = context.factory.create_job_service()
+    return await job_service.list_services()
+
+
+@router.get(
+    "/services/{service}/users",
+    description="List users with at least one job stored",
+    response_model=list[str],
+    summary="List users",
+    tags=["admin"],
+)
+async def list_users(
+    service: str,
+    *,
+    context: Annotated[RequestContext, Depends(context_dependency)],
+) -> list[str]:
+    job_service = context.factory.create_job_service()
+    return await job_service.list_users(service)
+
+
+@router.get(
+    "/services/{service}/users/{user}/jobs",
+    description="List jobs for a user and service",
+    response_model=list[Job],
+    response_model_exclude_defaults=True,
+    summary="List jobs",
+    tags=["admin"],
+)
+async def list_jobs(
+    service: str,
+    user: str,
+    *,
+    phase: Annotated[
+        list[ExecutionPhase] | None,
+        Query(
+            title="Execution phase",
+            description="Limit results to the provided execution phases",
+        ),
+    ] = None,
+    after: Annotated[
+        datetime | None,
+        Query(
+            title="Creation date",
+            description="Limit results to jobs created after this date",
+        ),
+    ] = None,
+    count: Annotated[
+        int | None,
+        Query(
+            title="Number of jobs",
+            description="Return at most the given number of jobs",
+        ),
+    ] = None,
+    context: Annotated[RequestContext, Depends(context_dependency)],
+) -> list[Job]:
+    job_service = context.factory.create_job_service()
+    return await job_service.list_jobs(
+        service, user, phases=phase, after=after, count=count
+    )
+
+
+@router.get(
+    "/services/{service}/users/{user}/jobs/{job_id}",
+    description="Retrieve the record for a single job",
+    response_model=Job,
+    response_model_exclude_defaults=True,
+    summary="Get job",
+)
+async def get_job(
+    service: str,
+    user: str,
+    job_id: str,
+    *,
+    context: Annotated[RequestContext, Depends(context_dependency)],
+) -> Job:
+    job_service = context.factory.create_job_service()
+    identifier = JobIdentifier(service=service, owner=user, id=job_id)
+    try:
+        return await job_service.get(identifier)
+    except UnknownJobError as e:
+        e.location = ErrorLocation.path
+        e.field_path = ["job_id"]
+        raise

--- a/src/wobbly/handlers/service.py
+++ b/src/wobbly/handlers/service.py
@@ -8,7 +8,7 @@ service.
 """
 
 from datetime import datetime
-from typing import Annotated, Any
+from typing import Annotated
 
 from fastapi import APIRouter, Depends, Header, Path, Query, Response
 from safir.dependencies.gafaelfawr import auth_dependency
@@ -80,12 +80,11 @@ async def list_jobs(
         ),
     ] = None,
     context: Annotated[RequestContext, Depends(context_dependency)],
-) -> list[dict[str, Any]]:
+) -> list[Job]:
     job_service = context.factory.create_job_service()
-    jobs = await job_service.list_jobs(
+    return await job_service.list_jobs(
         service, user, phases=phase, after=after, count=count
     )
-    return [j.model_dump(exclude={"service"}) for j in jobs]
 
 
 @router.post(

--- a/src/wobbly/main.py
+++ b/src/wobbly/main.py
@@ -18,7 +18,7 @@ from safir.logging import configure_logging, configure_uvicorn_logging
 from safir.middleware.x_forwarded import XForwardedMiddleware
 
 from .config import config
-from .handlers import internal, service
+from .handlers import admin, internal, service
 
 __all__ = ["app"]
 
@@ -53,7 +53,8 @@ app = FastAPI(
 
 # Attach the routers.
 app.include_router(internal.router)
-app.include_router(service.router, prefix=f"{config.path_prefix}")
+app.include_router(admin.router, prefix=config.path_prefix)
+app.include_router(service.router, prefix=config.path_prefix)
 
 # Add middleware.
 app.add_middleware(XForwardedMiddleware)

--- a/src/wobbly/models.py
+++ b/src/wobbly/models.py
@@ -237,6 +237,15 @@ class Job(JobBase):
         ),
     ]
 
+    service: Annotated[
+        str,
+        Field(
+            title="Service",
+            description="Service responsible for this job",
+            examples=["vo-cutouts"],
+        ),
+    ]
+
     owner: Annotated[
         str,
         Field(

--- a/src/wobbly/service.py
+++ b/src/wobbly/service.py
@@ -151,6 +151,31 @@ class JobService:
             count=count,
         )
 
+    async def list_services(self) -> list[str]:
+        """List the services that have any jobs stored.
+
+        Returns
+        -------
+        list of str
+            List of service names.
+        """
+        return await self._storage.list_services()
+
+    async def list_users(self, service: str) -> list[str]:
+        """List the users who have jobs for a given service.
+
+        Parameters
+        ----------
+        service
+            Name of the service.
+
+        Returns
+        -------
+        list of str
+            List of service names.
+        """
+        return await self._storage.list_users(service)
+
     async def update(self, job_id: JobIdentifier, update: JobUpdate) -> Job:
         """Update an existing job.
 

--- a/src/wobbly/storage.py
+++ b/src/wobbly/storage.py
@@ -280,7 +280,7 @@ class JobStore:
         Returns
         -------
         list of str
-            List of service names.
+            List of user names.
         """
         stmt = select(SQLJob.owner).where(SQLJob.service == service).distinct()
         async with self._session.begin():

--- a/src/wobbly/storage.py
+++ b/src/wobbly/storage.py
@@ -256,6 +256,37 @@ class JobStore:
             jobs = await self._session.execute(stmt)
             return [_convert_job(j) for j in jobs.scalars()]
 
+    async def list_services(self) -> list[str]:
+        """List the services that have any jobs stored.
+
+        Returns
+        -------
+        list of str
+            List of service names.
+        """
+        stmt = select(SQLJob.service).distinct()
+        async with self._session.begin():
+            services = await self._session.execute(stmt)
+            return list(services.scalars())
+
+    async def list_users(self, service: str) -> list[str]:
+        """List the users who have jobs for a given service.
+
+        Parameters
+        ----------
+        service
+            Name of the service.
+
+        Returns
+        -------
+        list of str
+            List of service names.
+        """
+        stmt = select(SQLJob.owner).where(SQLJob.service == service).distinct()
+        async with self._session.begin():
+            services = await self._session.execute(stmt)
+            return list(services.scalars())
+
     @retry_async_transaction
     async def mark_aborted(self, job_id: JobIdentifier) -> Job:
         """Mark a job as aborted.

--- a/src/wobbly/storage.py
+++ b/src/wobbly/storage.py
@@ -284,8 +284,8 @@ class JobStore:
         """
         stmt = select(SQLJob.owner).where(SQLJob.service == service).distinct()
         async with self._session.begin():
-            services = await self._session.execute(stmt)
-            return list(services.scalars())
+            users = await self._session.execute(stmt)
+            return list(users.scalars())
 
     @retry_async_transaction
     async def mark_aborted(self, job_id: JobIdentifier) -> Job:

--- a/src/wobbly/storage.py
+++ b/src/wobbly/storage.py
@@ -52,6 +52,7 @@ def _convert_job(job: SQLJob) -> Job:
         )
     return Job(
         id=str(job.id),
+        service=job.service,
         owner=job.owner,
         phase=job.phase,
         message_id=job.message_id,

--- a/tests/handlers/admin_test.py
+++ b/tests/handlers/admin_test.py
@@ -1,0 +1,59 @@
+"""Tests for Wobbly administrative API."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_admin(client: AsyncClient) -> None:
+    destruction = datetime.now(tz=UTC) + timedelta(days=30)
+    r = await client.post(
+        "/wobbly/jobs",
+        json={
+            "parameters": {"foo": "bar", "baz": "other"},
+            "destruction_time": destruction.isoformat(),
+        },
+        headers={
+            "X-Auth-Request-Service": "some-service",
+            "X-Auth-Request-User": "user",
+        },
+    )
+    assert r.status_code == 201
+    assert r.headers["Location"] == "https://example.com/wobbly/jobs/1"
+    job = r.json()
+
+    r = await client.get("/wobbly/services")
+    assert r.status_code == 200
+    assert r.json() == ["some-service"]
+
+    r = await client.get("/wobbly/services/some-service/users")
+    assert r.status_code == 200
+    assert r.json() == ["user"]
+
+    r = await client.get("/wobbly/services/some-service/users/user/jobs")
+    assert r.status_code == 200
+    assert r.json() == [job]
+
+    r = await client.get("/wobbly/services/some-service/users/user/jobs/1")
+    assert r.status_code == 200
+    assert r.json() == job
+
+    r = await client.get("/wobbly/services/other-service/users")
+    assert r.status_code == 200
+    assert r.json() == []
+    r = await client.get("/wobbly/services/other-service/users/user/jobs")
+    assert r.status_code == 200
+    assert r.json() == []
+    r = await client.get("/wobbly/services/other-service/users/user/jobs/1")
+    assert r.status_code == 404
+    r = await client.get("/wobbly/services/some-service/users/other-user/jobs")
+    assert r.status_code == 200
+    assert r.json() == []
+    r = await client.get(
+        "/wobbly/services/some-service/users/other-user/jobs/1"
+    )
+    assert r.status_code == 404

--- a/tests/handlers/admin_test.py
+++ b/tests/handlers/admin_test.py
@@ -26,34 +26,42 @@ async def test_admin(client: AsyncClient) -> None:
     assert r.headers["Location"] == "https://example.com/wobbly/jobs/1"
     job = r.json()
 
-    r = await client.get("/wobbly/services")
+    r = await client.get("/wobbly/admin/services")
     assert r.status_code == 200
     assert r.json() == ["some-service"]
 
-    r = await client.get("/wobbly/services/some-service/users")
+    r = await client.get("/wobbly/admin/services/some-service/users")
     assert r.status_code == 200
     assert r.json() == ["user"]
 
-    r = await client.get("/wobbly/services/some-service/users/user/jobs")
+    r = await client.get("/wobbly/admin/services/some-service/users/user/jobs")
     assert r.status_code == 200
     assert r.json() == [job]
 
-    r = await client.get("/wobbly/services/some-service/users/user/jobs/1")
+    r = await client.get(
+        "/wobbly/admin/services/some-service/users/user/jobs/1"
+    )
     assert r.status_code == 200
     assert r.json() == job
 
-    r = await client.get("/wobbly/services/other-service/users")
-    assert r.status_code == 200
-    assert r.json() == []
-    r = await client.get("/wobbly/services/other-service/users/user/jobs")
-    assert r.status_code == 200
-    assert r.json() == []
-    r = await client.get("/wobbly/services/other-service/users/user/jobs/1")
-    assert r.status_code == 404
-    r = await client.get("/wobbly/services/some-service/users/other-user/jobs")
+    r = await client.get("/wobbly/admin/services/other-service/users")
     assert r.status_code == 200
     assert r.json() == []
     r = await client.get(
-        "/wobbly/services/some-service/users/other-user/jobs/1"
+        "/wobbly/admin/services/other-service/users/user/jobs"
+    )
+    assert r.status_code == 200
+    assert r.json() == []
+    r = await client.get(
+        "/wobbly/admin/services/other-service/users/user/jobs/1"
+    )
+    assert r.status_code == 404
+    r = await client.get(
+        "/wobbly/admin/services/some-service/users/other-user/jobs"
+    )
+    assert r.status_code == 200
+    assert r.json() == []
+    r = await client.get(
+        "/wobbly/admin/services/some-service/users/other-user/jobs/1"
     )
     assert r.status_code == 404

--- a/tests/handlers/service_test.py
+++ b/tests/handlers/service_test.py
@@ -35,6 +35,7 @@ async def test_create(client: AsyncClient) -> None:
     job = r.json()
     assert job == {
         "id": "1",
+        "service": "some-service",
         "owner": "user",
         "phase": "PENDING",
         "parameters": {"foo": "bar", "baz": "other"},
@@ -71,6 +72,7 @@ async def test_create(client: AsyncClient) -> None:
     other_job = r.json()
     assert other_job == {
         "id": "2",
+        "service": "some-service",
         "owner": "other-user",
         "phase": "PENDING",
         "run_id": "big-job",


### PR DESCRIPTION
Add an administrative API that allows retrieving the list of services and users within a service that have at least one job and retrieving a list of jobs and a single job given a user and service.

This also cleans up some code returning a list of jobs that I realized was unnecessary since we already strip the service out of the job model at the database layer.