### PR TITLE
DM-47262: Remove version bounds on dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,8 @@ dependencies = [
     "pydantic>2",
     "pydantic-settings",
     "safir[db]>=6.5.1",
-    "sqlalchemy[asyncio]>=2.0.0,<3",
-    "vo-models>=0.4.1,<1",
+    "sqlalchemy[asyncio]>=2.0.0",
+    "vo-models>=0.4.1",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
This is an application with frozen dependencies, so there's no need to put upper version bounds on dependencies.