### PR TITLE
DM-47769: Use drop_database from Safir

### DIFF
--- a/tests/schema_test.py
+++ b/tests/schema_test.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import subprocess
 
 import pytest
-from safir.database import create_database_engine, unstamp_database
+from safir.database import create_database_engine, drop_database
 
 from wobbly.config import config
 from wobbly.schema import SchemaBase
@@ -22,9 +22,7 @@ async def test_schema() -> None:
     engine = create_database_engine(
         config.database_url, config.database_password
     )
-    async with engine.begin() as conn:
-        await conn.run_sync(SchemaBase.metadata.drop_all)
-    await unstamp_database(engine)
+    await drop_database(engine, SchemaBase.metadata)
     await engine.dispose()
     subprocess.run(["alembic", "upgrade", "head"], check=True)
     subprocess.run(["alembic", "check"], check=True)


### PR DESCRIPTION
Now that Safir provides a `drop_database` utility function, use it for the schema test rather than inlining it.