### PR TITLE
DM-47986: Standardize metrics tags, add tests

### DIFF
--- a/src/wobbly/events.py
+++ b/src/wobbly/events.py
@@ -26,7 +26,7 @@ class JobEvent(EventPayload):
         str, Field(title="Service", description="Service managing the job")
     ]
 
-    owner: Annotated[str, Field(title="Owner", description="Owner of job")]
+    username: Annotated[str, Field(title="Owner", description="Owner of job")]
 
 
 class AbortedJobEvent(JobEvent):

--- a/src/wobbly/service.py
+++ b/src/wobbly/service.py
@@ -75,7 +75,7 @@ class JobService:
             Full job record of the newly-created job.
         """
         job = await self._storage.add(service, owner, job_data)
-        event = CreatedJobEvent(service=service, owner=owner)
+        event = CreatedJobEvent(service=service, username=owner)
         await self._events.created.publish(event)
         self._logger.info(
             "Created job", service=service, owner=owner, job=job.id
@@ -206,7 +206,7 @@ class JobService:
             case JobUpdateAborted():
                 job = await self._storage.mark_aborted(job_id)
                 aborted_event = AbortedJobEvent(
-                    service=job.service, owner=job.owner
+                    service=job.service, username=job.owner
                 )
                 await self._events.aborted.publish(aborted_event)
                 logger = logger.bind(phase=job.phase.value)
@@ -219,7 +219,7 @@ class JobService:
                     raise RuntimeError(msg)
                 completed_event = CompletedJobEvent(
                     service=job.service,
-                    owner=job.owner,
+                    username=job.owner,
                     elapsed=job.end_time - job.start_time,
                 )
                 await self._events.completed.publish(completed_event)
@@ -231,7 +231,7 @@ class JobService:
                     raise RuntimeError(msg)
                 failed_event = FailedJobEvent(
                     service=job.service,
-                    owner=job.owner,
+                    username=job.owner,
                     error_code=update.errors[0].code,
                     elapsed=job.end_time - job.start_time,
                 )
@@ -256,7 +256,7 @@ class JobService:
                     job_id, update.message_id
                 )
                 queued_event = QueuedJobEvent(
-                    service=job.service, owner=job.owner
+                    service=job.service, username=job.owner
                 )
                 await self._events.queued.publish(queued_event)
                 logger = logger.bind(

--- a/tox.ini
+++ b/tox.ini
@@ -59,6 +59,7 @@ docker =
 setenv =
     METRICS_APPLICATION = wobbly
     METRICS_ENABLED = false
+    METRICS_MOCK = true
     POSTGRES_USER = wobbly
     POSTGRES_DB = wobbly
     POSTGRES_PASSWORD = INSECURE-PASSWORD


### PR DESCRIPTION
Change the owner tag on all metrics events to username to match Gafaelfawr, since consistency between projects will be more useful than exact precision in terminology. Add tests for the Wobbly metrics events.