### PR TITLE
DM-47986: Add a health check route

### DIFF
--- a/src/wobbly/models.py
+++ b/src/wobbly/models.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
+from enum import Enum
 from typing import Annotated, Self, TypeAlias
 
 from pydantic import BaseModel, Field
@@ -24,12 +25,30 @@ from vo_models.uws.types import ExecutionPhase
 from .schema import Job as SQLJob
 
 __all__ = [
+    "HealthCheck",
+    "HealthStatus",
     "Index",
     "JobCursor",
     "JobIdentifier",
     "JobSearch",
     "JobUpdate",
 ]
+
+
+class HealthStatus(Enum):
+    """Status of health check.
+
+    Since errors are returned as HTTP 500 errors, currently the only status is
+    the healthy status.
+    """
+
+    HEALTHY = "healthy"
+
+
+class HealthCheck(BaseModel):
+    """Results of an internal health check."""
+
+    status: Annotated[HealthStatus, Field(title="Health status")]
 
 
 class Index(BaseModel):
@@ -82,16 +101,16 @@ class JobCursor(DatetimeIdCursor[SerializedJob]):
 class JobSearch:
     """Collects common search parameters for jobs."""
 
-    phases: set[ExecutionPhase] | None
+    phases: set[ExecutionPhase] | None = None
     """Include only jobs in the given phases."""
 
-    since: datetime | None
+    since: datetime | None = None
     """Include only jobs created after the given time."""
 
-    cursor: JobCursor | None
+    cursor: JobCursor | None = None
     """Cursor for retrieving paginated results."""
 
-    limit: int | None
+    limit: int | None = None
     """Limit the number of jobs returned to at most this count."""
 
 

--- a/src/wobbly/service.py
+++ b/src/wobbly/service.py
@@ -27,7 +27,14 @@ from .events import (
     QueuedJobEvent,
 )
 from .exceptions import UnknownJobError
-from .models import JobCursor, JobIdentifier, JobSearch, JobUpdate
+from .models import (
+    HealthCheck,
+    HealthStatus,
+    JobCursor,
+    JobIdentifier,
+    JobSearch,
+    JobUpdate,
+)
 from .storage import JobStore
 
 __all__ = ["JobService"]
@@ -124,6 +131,24 @@ class JobService:
             Raised if the job was not found.
         """
         return await self._storage.get(job_id)
+
+    async def health(self) -> HealthCheck:
+        """Check health of service.
+
+        Intended for use as the Kubernetes health check endpoint.
+
+        Returns
+        -------
+        HealthCheck
+            Health check results if the service seems healthy.
+
+        Raises
+        ------
+        Exception
+            Raised if there is some problem querying the database.
+        """
+        await self._storage.list_jobs(JobSearch(limit=1))
+        return HealthCheck(status=HealthStatus.HEALTHY)
 
     async def list_jobs(
         self,


### PR DESCRIPTION
Add a new internal `/health` route that attempts to do a database query and returns 200 if it succeeds, 500 if it fails. This intentionally doesn't use the VOSI XML output syntax since no IVOA client should be talking directly to Wobbly.