### PR TITLE
DM-48184: Add wobbly expire command

### DIFF
--- a/changelog.d/20241217_122642_rra_DM_48184.md
+++ b/changelog.d/20241217_122642_rra_DM_48184.md
@@ -1,0 +1,3 @@
+### New features
+
+- Add a `wobbly expire` command that deletes all jobs from the database that have passed their destruction time. This is run periodically as a Kubernetes `CronJob`.

--- a/src/wobbly/cli.py
+++ b/src/wobbly/cli.py
@@ -16,7 +16,6 @@ from safir.database import (
     is_database_current,
     stamp_database,
 )
-from safir.logging import configure_logging
 
 from .config import config
 from .factory import Factory
@@ -60,9 +59,6 @@ async def expire(*, alembic_config_path: Path) -> None:
     Delete jobs that have passed their destruction time. The job records are
     deleted in their entirety.
     """
-    configure_logging(
-        profile=config.profile, log_level=config.log_level, name="wobbly"
-    )
     logger = structlog.get_logger("wobbly")
     engine = create_database_engine(
         config.database_url, config.database_password

--- a/src/wobbly/config.py
+++ b/src/wobbly/config.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pydantic import Field, SecretStr
 from pydantic_settings import BaseSettings, SettingsConfigDict
-from safir.logging import LogLevel, Profile
+from safir.logging import LogLevel, Profile, configure_logging
 from safir.metrics import MetricsConfiguration, metrics_configuration_factory
 from safir.pydantic import EnvAsyncPostgresDsn
 
@@ -54,3 +54,9 @@ class Config(BaseSettings):
 
 config = Config()
 """Configuration for wobbly."""
+
+
+# Ensure this is always run so that command-line tools can rely on it as well.
+configure_logging(
+    profile=config.profile, log_level=config.log_level, name="wobbly"
+)

--- a/src/wobbly/main.py
+++ b/src/wobbly/main.py
@@ -55,9 +55,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
 
 configure_logging(
-    profile=config.profile,
-    log_level=config.log_level,
-    name="wobbly",
+    profile=config.profile, log_level=config.log_level, name="wobbly"
 )
 configure_uvicorn_logging(config.log_level)
 

--- a/src/wobbly/main.py
+++ b/src/wobbly/main.py
@@ -18,7 +18,7 @@ from fastapi import FastAPI
 from safir.database import create_database_engine, is_database_current
 from safir.dependencies.db_session import db_session_dependency
 from safir.fastapi import ClientRequestError, client_request_error_handler
-from safir.logging import configure_logging, configure_uvicorn_logging
+from safir.logging import configure_uvicorn_logging
 from safir.middleware.x_forwarded import XForwardedMiddleware
 from safir.slack.webhook import SlackRouteErrorHandler
 
@@ -54,9 +54,6 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     await event_manager.aclose()
 
 
-configure_logging(
-    profile=config.profile, log_level=config.log_level, name="wobbly"
-)
 configure_uvicorn_logging(config.log_level)
 
 app = FastAPI(

--- a/src/wobbly/service.py
+++ b/src/wobbly/service.py
@@ -126,19 +126,7 @@ class JobService:
         jobs = await self._storage.list_expired()
         if jobs:
             self._logger.info(f"Deleting {len(jobs)} expired jobs")
-        count = 0
-        for job in jobs:
-            job_id = JobIdentifier(
-                service=job.service, owner=job.owner, id=job.id
-            )
-            if await self._storage.delete(job_id):
-                self._logger.info(
-                    "Deleted expired job",
-                    service=job.service,
-                    owner=job.owner,
-                    job=job.id,
-                )
-                count += 1
+        count = await self._storage.delete_list(j.id for j in jobs)
         self._logger.info(f"Finished deleting {count} expired jobs")
 
     async def get(self, job_id: JobIdentifier) -> SerializedJob:

--- a/src/wobbly/service.py
+++ b/src/wobbly/service.py
@@ -112,6 +112,35 @@ class JobService:
             job=job_id.id,
         )
 
+    async def delete_expired(self) -> None:
+        """Delete all jobs that have passed their destruction time.
+
+        The jobs are deleted out of the database entirely, not moved to
+        ``ARCHIVED`` status.
+
+        Be aware that Wobbly has no access to the job queue and therefore
+        cannot cancel deleted jobs, so if the destruction time is very short,
+        the job may still be executing, and the attempt to update the record
+        when it completes will fail with an HTTP 404 error.
+        """
+        jobs = await self._storage.list_expired()
+        if jobs:
+            self._logger.info(f"Deleting {len(jobs)} expired jobs")
+        count = 0
+        for job in jobs:
+            job_id = JobIdentifier(
+                service=job.service, owner=job.owner, id=job.id
+            )
+            if await self._storage.delete(job_id):
+                self._logger.info(
+                    "Deleted expired job",
+                    service=job.service,
+                    owner=job.owner,
+                    job=job.id,
+                )
+                count += 1
+        self._logger.info(f"Finished deleting {count} expired jobs")
+
     async def get(self, job_id: JobIdentifier) -> SerializedJob:
         """Retrieve a job by ID.
 

--- a/src/wobbly/storage.py
+++ b/src/wobbly/storage.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from datetime import UTC, datetime
 
 from safir.database import (
@@ -112,6 +113,26 @@ class JobStore:
         async with self._session.begin():
             result = await self._session.execute(stmt)
             return result.rowcount >= 1
+
+    async def delete_list(self, job_ids: Iterable[str]) -> int:
+        """Delete a list of jobs.
+
+        Parameters
+        ----------
+        job_ids
+            Identifiers of jobs to delete. This is only the unique key, not
+            the service and owner. The caller is responsible for any needed
+            verification of job ownership.
+
+        Returns
+        -------
+        int
+            Count of rows affected.
+        """
+        stmt = delete(SQLJob).where(SQLJob.id.in_(int(i) for i in job_ids))
+        async with self._session.begin():
+            result = await self._session.execute(stmt)
+            return result.rowcount
 
     async def get(self, job_id: JobIdentifier) -> SerializedJob:
         """Retrieve a job by ID.

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -1,0 +1,76 @@
+"""Tests for the Wobbly command-line interface.
+
+Be careful when writing tests in this framework because the click command
+handling code spawns its own async worker pools when needed. None of these
+tests can therefore be async, and should instead run coroutines using the
+``event_loop`` fixture when needed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import timedelta
+from pathlib import Path
+
+import structlog
+from click.testing import CliRunner
+from safir.database import (
+    create_database_engine,
+    initialize_database,
+    stamp_database_async,
+)
+from safir.datetime import current_datetime
+from safir.uws import JobCreate
+
+from wobbly.cli import main
+from wobbly.config import config
+from wobbly.factory import Factory
+from wobbly.models import JobSearch
+from wobbly.schema import SchemaBase
+
+
+def test_expire(event_loop: asyncio.AbstractEventLoop) -> None:
+    engine = create_database_engine(
+        config.database_url, config.database_password
+    )
+    logger = structlog.get_logger(__name__)
+    job_create_one = JobCreate(
+        json_parameters={}, destruction_time=current_datetime()
+    )
+    job_create_two = JobCreate(
+        json_parameters={},
+        destruction_time=current_datetime() + timedelta(days=30),
+    )
+
+    async def setup() -> None:
+        await initialize_database(
+            engine, logger, schema=SchemaBase.metadata, reset=True
+        )
+        await stamp_database_async(engine)
+        async with Factory.standalone(engine, logger) as factory:
+            job_service = factory.create_job_service()
+            await job_service.create("service", "owner", job_create_one)
+            await job_service.create("service", "owner", job_create_two)
+            jobs = await job_service.list_jobs(JobSearch())
+            assert len(jobs.entries) == 2
+
+    event_loop.run_until_complete(setup())
+    runner = CliRunner()
+    alembic_config_path = str(Path(__file__).parent.parent / "alembic.ini")
+    result = runner.invoke(
+        main,
+        ["expire", "--alembic-config-path", alembic_config_path],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+
+    async def check() -> None:
+        async with Factory.standalone(engine, logger) as factory:
+            job_service = factory.create_job_service()
+            jobs = await job_service.list_jobs(JobSearch())
+            assert len(jobs.entries) == 1
+            seen = jobs.entries[0].destruction_time
+            assert seen == job_create_two.destruction_time
+        await engine.dispose()
+
+    event_loop.run_until_complete(check())


### PR DESCRIPTION
Add a new command, `wobbly expire`, that deletes all jobs from the database that have passed their destruction time. This will be run periodically as a Kubernetes `CronJob` in Phalanx.