### PR TITLE
DM-51443: Change AsyncIterator types to AsyncGenerator

### DIFF
--- a/src/wobbly/factory.py
+++ b/src/wobbly/factory.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from typing import Self
 
@@ -37,7 +37,7 @@ class Factory:
     @asynccontextmanager
     async def standalone(
         cls, engine: AsyncEngine, logger: BoundLogger
-    ) -> AsyncIterator[Self]:
+    ) -> AsyncGenerator[Self]:
         """Async context manager for Wobbly components.
 
         Intended for background jobs.

--- a/src/wobbly/main.py
+++ b/src/wobbly/main.py
@@ -9,7 +9,7 @@ called.
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from importlib.metadata import metadata, version
 
@@ -30,7 +30,7 @@ __all__ = ["app"]
 
 
 @asynccontextmanager
-async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     """Set up and tear down the application."""
     logger = structlog.get_logger("wobbly")
     engine = create_database_engine(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 
 import pytest_asyncio
 import structlog
@@ -26,7 +26,7 @@ __all__ = [
 
 
 @pytest_asyncio.fixture
-async def app() -> AsyncIterator[FastAPI]:
+async def app() -> AsyncGenerator[FastAPI]:
     """Return a configured test application.
 
     Wraps the application in a lifespan manager so that startup and shutdown
@@ -46,7 +46,7 @@ async def app() -> AsyncIterator[FastAPI]:
 
 
 @pytest_asyncio.fixture
-async def client(app: FastAPI) -> AsyncIterator[AsyncClient]:
+async def client(app: FastAPI) -> AsyncGenerator[AsyncClient]:
     """Return an ``httpx.AsyncClient`` configured to talk to the test app."""
     async with AsyncClient(
         transport=ASGITransport(app=app), base_url="https://example.com/"


### PR DESCRIPTION
This is more accurate for simple async functions that call `yield`, since those functions create a generator that has an `aclose` method.