### PR TITLE
DM-51443: Use cache file system for Docker apt actions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,9 @@ FROM python:3.13.5-slim-bookworm AS base-image
 
 # Update system packages.
 COPY scripts/install-base-packages.sh .
-RUN ./install-base-packages.sh && rm ./install-base-packages.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    ./install-base-packages.sh && rm ./install-base-packages.sh
 
 FROM base-image AS install-image
 
@@ -25,7 +27,9 @@ COPY --from=ghcr.io/astral-sh/uv:0.7.13 /uv /bin/uv
 
 # Install system packages only needed for building dependencies.
 COPY scripts/install-dependency-packages.sh .
-RUN ./install-dependency-packages.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    ./install-dependency-packages.sh
 
 # Create a Python virtual environment.
 ENV VIRTUAL_ENV=/opt/venv

--- a/scripts/install-base-packages.sh
+++ b/scripts/install-base-packages.sh
@@ -1,16 +1,15 @@
 #!/bin/bash
 
-# This script updates packages in the base Docker image that's used by both the
-# build and runtime images, and gives us a place to install additional
+# This script updates packages in the base Docker image that's used by both
+# the build and runtime images, and gives us a place to install additional
 # system-level packages with apt-get.
 #
 # Based on the blog post:
 # https://pythonspeed.com/articles/system-packages-docker/
 
-# Bash "strict mode", to help catch problems and bugs in the shell
-# script. Every bash script you write should include this. See
-# http://redsymbol.net/articles/unofficial-bash-strict-mode/ for
-# details.
+# Bash "strict mode", to help catch problems and bugs in the shell script.
+# Every bash script you write should include this. See
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/ for details.
 set -euo pipefail
 
 # Display each command as it's run.
@@ -26,9 +25,5 @@ apt-get update
 # Install security updates:
 apt-get -y upgrade
 
-# Example of installing a new package, without unnecessary packages:
-apt-get -y install --no-install-recommends git
-
-# Delete cached files we don't need anymore:
-apt-get clean
-rm -rf /var/lib/apt/lists/*
+# Install dependencies required at runtime (none currently).
+#apt-get -y install --no-install-recommends

--- a/scripts/install-dependency-packages.sh
+++ b/scripts/install-dependency-packages.sh
@@ -8,10 +8,9 @@
 # will be reused by the runtime image, we unfortunately have to do another
 # apt-get update here, which wastes some time and network.
 
-# Bash "strict mode", to help catch problems and bugs in the shell
-# script. Every bash script you write should include this. See
-# http://redsymbol.net/articles/unofficial-bash-strict-mode/ for
-# details.
+# Bash "strict mode", to help catch problems and bugs in the shell script.
+# Every bash script you write should include this. See
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/ for details.
 set -euo pipefail
 
 # Display each command as it's run.
@@ -24,11 +23,9 @@ export DEBIAN_FRONTEND=noninteractive
 # Update the package listing, so we know what packages exist:
 apt-get update
 
-# Install build-essential because sometimes Python dependencies need to build
-# C modules, particularly when upgrading to newer Python versions.  libffi-dev
-# is sometimes needed to build cffi (a cryptography dependency).
-apt-get -y install --no-install-recommends build-essential libffi-dev
-
-# Delete cached files we don't need anymore:
-apt-get clean
-rm -rf /var/lib/apt/lists/*
+# Install various dependencies that may be required to install vo-cutouts:
+#
+# build-essential: sometimes needed to build Python modules
+# git: required by setuptools_scm
+# libffi-dev: sometimes needed to build cffi, a cryptography dependency
+apt-get -y install --no-install-recommends build-essential git libffi-dev


### PR DESCRIPTION
When upgrading and installing packages, use the Docker cache file system to hold the apt cache and lists. This removes the need to explicitly clean up the lists after installation.