### PR TITLE
DM-52774: Include job ID in metrics events

### DIFF
--- a/changelog.d/20251006_133509_rra_DM_52774.md
+++ b/changelog.d/20251006_133509_rra_DM_52774.md
@@ -1,0 +1,3 @@
+### Other changes
+
+- Include the UWS job ID in metrics events so that timings can be traced back to the original request.

--- a/src/wobbly/events.py
+++ b/src/wobbly/events.py
@@ -28,6 +28,8 @@ class JobEvent(EventPayload):
 
     username: Annotated[str, Field(title="Owner", description="Owner of job")]
 
+    job_id: Annotated[str, Field(title="Job ID", description="UWS job ID")]
+
 
 class AbortedJobEvent(JobEvent):
     """A job was aborted."""

--- a/src/wobbly/service.py
+++ b/src/wobbly/service.py
@@ -82,7 +82,7 @@ class JobService:
             Full job record of the newly-created job.
         """
         job = await self._storage.add(service, owner, job_data)
-        event = CreatedJobEvent(service=service, username=owner)
+        event = CreatedJobEvent(service=service, username=owner, job_id=job.id)
         await self._events.created.publish(event)
         self._logger.info(
             "Created job", service=service, owner=owner, job=job.id
@@ -248,7 +248,7 @@ class JobService:
             case JobUpdateAborted():
                 job = await self._storage.mark_aborted(job_id)
                 aborted_event = AbortedJobEvent(
-                    service=job.service, username=job.owner
+                    service=job.service, username=job.owner, job_id=job_id.id
                 )
                 await self._events.aborted.publish(aborted_event)
                 logger = logger.bind(phase=job.phase.value)
@@ -262,6 +262,7 @@ class JobService:
                 completed_event = CompletedJobEvent(
                     service=job.service,
                     username=job.owner,
+                    job_id=job_id.id,
                     elapsed=job.end_time - job.start_time,
                 )
                 await self._events.completed.publish(completed_event)
@@ -274,6 +275,7 @@ class JobService:
                 failed_event = FailedJobEvent(
                     service=job.service,
                     username=job.owner,
+                    job_id=job_id.id,
                     error_code=update.errors[0].code,
                     elapsed=job.end_time - job.start_time,
                 )
@@ -298,7 +300,7 @@ class JobService:
                     job_id, update.message_id
                 )
                 queued_event = QueuedJobEvent(
-                    service=job.service, username=job.owner
+                    service=job.service, username=job.owner, job_id=job_id.id
                 )
                 await self._events.queued.publish(queued_event)
                 logger = logger.bind(

--- a/tests/handlers/service_test.py
+++ b/tests/handlers/service_test.py
@@ -188,15 +188,22 @@ async def test_completed(client: AsyncClient) -> None:
     manager = context_dependency._events
     assert isinstance(manager.created, MockEventPublisher)
     manager.created.published.assert_published_all(
-        [{"service": "some-service", "username": "user"}]
+        [{"service": "some-service", "username": "user", "job_id": "1"}]
     )
     assert isinstance(manager.queued, MockEventPublisher)
     manager.queued.published.assert_published_all(
-        [{"service": "some-service", "username": "user"}]
+        [{"service": "some-service", "username": "user", "job_id": "1"}]
     )
     assert isinstance(manager.completed, MockEventPublisher)
     manager.completed.published.assert_published_all(
-        [{"service": "some-service", "username": "user", "elapsed": NOT_NONE}]
+        [
+            {
+                "service": "some-service",
+                "username": "user",
+                "job_id": "1",
+                "elapsed": NOT_NONE,
+            }
+        ]
     )
 
 
@@ -253,11 +260,11 @@ async def test_failed(client: AsyncClient) -> None:
     manager = context_dependency._events
     assert isinstance(manager.created, MockEventPublisher)
     manager.created.published.assert_published_all(
-        [{"service": "some-service", "username": "user"}]
+        [{"service": "some-service", "username": "user", "job_id": "1"}]
     )
     assert isinstance(manager.queued, MockEventPublisher)
     manager.queued.published.assert_published_all(
-        [{"service": "some-service", "username": "user"}]
+        [{"service": "some-service", "username": "user", "job_id": "1"}]
     )
     assert isinstance(manager.failed, MockEventPublisher)
     manager.failed.published.assert_published_all(
@@ -265,6 +272,7 @@ async def test_failed(client: AsyncClient) -> None:
             {
                 "service": "some-service",
                 "username": "user",
+                "job_id": "1",
                 "error_code": "SomeError",
                 "elapsed": NOT_NONE,
             }
@@ -301,11 +309,11 @@ async def test_aborted(client: AsyncClient) -> None:
     manager = context_dependency._events
     assert isinstance(manager.created, MockEventPublisher)
     manager.created.published.assert_published_all(
-        [{"service": "some-service", "username": "user"}]
+        [{"service": "some-service", "username": "user", "job_id": "1"}]
     )
     assert isinstance(manager.aborted, MockEventPublisher)
     manager.aborted.published.assert_published_all(
-        [{"service": "some-service", "username": "user"}]
+        [{"service": "some-service", "username": "user", "job_id": "1"}]
     )
 
 


### PR DESCRIPTION
Include the UWS job ID in metrics events so that timings can be traced back to the original request.