### PR TITLE
DM-52774: Log usernames as user, not owner

### DIFF
--- a/changelog.d/20251006_133948_rra_DM_52774.md
+++ b/changelog.d/20251006_133948_rra_DM_52774.md
@@ -1,0 +1,3 @@
+### Other changes
+
+- Log usernames as `user` rather than `owner` in structured logging to match other services and make cross-matching easier.

--- a/src/wobbly/service.py
+++ b/src/wobbly/service.py
@@ -85,7 +85,7 @@ class JobService:
         event = CreatedJobEvent(service=service, username=owner, job_id=job.id)
         await self._events.created.publish(event)
         self._logger.info(
-            "Created job", service=service, owner=owner, job=job.id
+            "Created job", service=service, user=owner, job=job.id
         )
         return job
 
@@ -108,7 +108,7 @@ class JobService:
         self._logger.info(
             "Deleted job",
             service=job_id.service,
-            owner=job_id.owner,
+            user=job_id.owner,
             job=job_id.id,
         )
 
@@ -242,7 +242,7 @@ class JobService:
             Raised if the job was not found.
         """
         logger = self._logger.bind(
-            service=job_id.service, owner=job_id.owner, job=job_id.id
+            service=job_id.service, user=job_id.owner, job=job_id.id
         )
         match update:
             case JobUpdateAborted():


### PR DESCRIPTION
Although Wobbly uses the terminology of job owner for everything internally, other applications log the user as `user` in structured logging. To make cross-match queries in Google Log Explorer easier, use `user` in Wobbly as well, instead of `owner`.