### PR TITLE
DM-52774: Prepare 1.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ Find changes for the upcoming release in the project's [changelog.d directory](h
 
 <!-- scriv-insert-here -->
 
+<a id='changelog-1.1.0'></a>
+## 1.1.0 (2025-10-06)
+
+### New features
+
+- Add optional support for reporting exceptions to Sentry.
+
+### Other changes
+
+- Include the UWS job ID in metrics events so that timings can be traced back to the original request.
+- Log usernames as `user` rather than `owner` in structured logging to match other services and make cross-matching easier.
+
 <a id='changelog-1.0.0'></a>
 ## 1.0.0 (2025-06-17)
 

--- a/changelog.d/20251006_133509_rra_DM_52774.md
+++ b/changelog.d/20251006_133509_rra_DM_52774.md
@@ -1,3 +1,0 @@
-### Other changes
-
-- Include the UWS job ID in metrics events so that timings can be traced back to the original request.

--- a/changelog.d/20251006_133948_rra_DM_52774.md
+++ b/changelog.d/20251006_133948_rra_DM_52774.md
@@ -1,3 +1,0 @@
-### Other changes
-
-- Log usernames as `user` rather than `owner` in structured logging to match other services and make cross-matching easier.

--- a/changelog.d/20251006_144640_rra_DM_52774.md
+++ b/changelog.d/20251006_144640_rra_DM_52774.md
@@ -1,3 +1,0 @@
-### New features
-
-- Add optional support for reporting exceptions to Sentry.

--- a/ruff-shared.toml
+++ b/ruff-shared.toml
@@ -20,7 +20,6 @@
 # Reference for rules: https://docs.astral.sh/ruff/rules/
 exclude = ["docs/**"]
 line-length = 79
-target-version = "py312"
 
 [format]
 docstring-code-format = true

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py,coverage-report,typing,lint
 isolated_build = True
 
 [docker:postgres]
-image = postgres:latest
+image = postgres:18
 environment =
     POSTGRES_PASSWORD=INSECURE-PASSWORD
     POSTGRES_USER=wobbly


### PR DESCRIPTION
Collect the change log for the 1.1.0 release. Update the shared Ruff configuration file and bump the version of the PostgreSQL container used for testing.