### PR TITLE
DM-52774: Include Alembic files in the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,9 @@ FROM base-image AS runtime-image
 # Create a non-root user.
 RUN useradd --create-home appuser
 
-# Copy the virtualenv.
+# Copy the virtualenv and the Alembic configuration.
+COPY --from=install-image /app/alembic /app/alembic
+COPY --from=install-image /app/alembic.ini /app/alembic.ini
 COPY --from=install-image /app/.venv /app/.venv
 
 # Switch to the non-root user.

--- a/changelog.d/20251006_162805_rra_DM_52774.md
+++ b/changelog.d/20251006_162805_rra_DM_52774.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Include Alembic configuration in the built image, fixing a regression introduced in 1.1.0.


### PR DESCRIPTION
Copying only the virtual environment broke Alembic schema management.