### PR TITLE
DM-54892: Prevent uv from changing Docker Python version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,10 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 # cache on a separate file system.
 ENV UV_LINK_MODE=copy
 
+# Force use of system Python so that the Python version is controlled by
+# the Docker base image version, not by whatever uv decides to install.
+ENV UV_PYTHON_PREFERENCE=only-system
+
 # Install the dependencies.
 WORKDIR /app
 RUN --mount=type=cache,target=/root/.cache/uv \


### PR DESCRIPTION
Force use of system Python in the Docker build so that uv doesn't install its own version of Python.