### PR TITLE
DM-54892: Remove deprecated annotations approach

### DIFF
--- a/src/wobbly/cli.py
+++ b/src/wobbly/cli.py
@@ -1,7 +1,5 @@
 """Administrative command-line interface."""
 
-from __future__ import annotations
-
 import asyncio
 import subprocess
 from pathlib import Path

--- a/src/wobbly/config.py
+++ b/src/wobbly/config.py
@@ -1,7 +1,5 @@
 """Configuration definition."""
 
-from __future__ import annotations
-
 from pydantic import Field, SecretStr
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from safir.logging import LogLevel, Profile, configure_logging

--- a/src/wobbly/events.py
+++ b/src/wobbly/events.py
@@ -1,7 +1,5 @@
 """Metrics implementation for Wobbly."""
 
-from __future__ import annotations
-
 from datetime import timedelta
 from typing import Annotated
 

--- a/src/wobbly/exceptions.py
+++ b/src/wobbly/exceptions.py
@@ -1,7 +1,5 @@
 """Exceptions for the UWS storage service."""
 
-from __future__ import annotations
-
 from fastapi import status
 from safir.fastapi import ClientRequestError
 from safir.models import ErrorLocation

--- a/src/wobbly/factory.py
+++ b/src/wobbly/factory.py
@@ -1,7 +1,5 @@
 """Component factory for Wobbly."""
 
-from __future__ import annotations
-
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from typing import Self

--- a/src/wobbly/main.py
+++ b/src/wobbly/main.py
@@ -7,8 +7,6 @@ constructed when this module is loaded and is not deferred until a function is
 called.
 """
 
-from __future__ import annotations
-
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from importlib.metadata import metadata, version

--- a/src/wobbly/models.py
+++ b/src/wobbly/models.py
@@ -1,7 +1,5 @@
 """Models for Wobbly."""
 
-from __future__ import annotations
-
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum

--- a/src/wobbly/schema/__init__.py
+++ b/src/wobbly/schema/__init__.py
@@ -1,7 +1,5 @@
 """SQLAlchemy schema for the UWS database."""
 
-from __future__ import annotations
-
 from .base import SchemaBase
 from .error import JobError
 from .job import Job

--- a/src/wobbly/schema/base.py
+++ b/src/wobbly/schema/base.py
@@ -1,7 +1,5 @@
 """Declarative base for the UWS database schema."""
 
-from __future__ import annotations
-
 from typing import ClassVar
 
 from sqlalchemy import Text

--- a/src/wobbly/schema/error.py
+++ b/src/wobbly/schema/error.py
@@ -1,7 +1,5 @@
 """SQLAlchemy schema for errors for a UWS job."""
 
-from __future__ import annotations
-
 from sqlalchemy import ForeignKey
 from sqlalchemy.orm import Mapped, mapped_column
 from vo_models.uws.types import ErrorType

--- a/src/wobbly/schema/job.py
+++ b/src/wobbly/schema/job.py
@@ -1,7 +1,5 @@
 """SQLAlchemy schema for UWS jobs."""
 
-from __future__ import annotations
-
 from datetime import datetime
 from typing import Any
 

--- a/src/wobbly/schema/result.py
+++ b/src/wobbly/schema/result.py
@@ -1,7 +1,5 @@
 """SQLAlchemy schema for results for a UWS job."""
 
-from __future__ import annotations
-
 from sqlalchemy import ForeignKey, Index
 from sqlalchemy.orm import Mapped, mapped_column
 

--- a/src/wobbly/service.py
+++ b/src/wobbly/service.py
@@ -1,7 +1,5 @@
 """Service layer for the UWS storage service."""
 
-from __future__ import annotations
-
 from typing import assert_never
 
 from safir.database import PaginatedList

--- a/src/wobbly/storage.py
+++ b/src/wobbly/storage.py
@@ -1,7 +1,5 @@
 """Storage layer for the UWS implementation."""
 
-from __future__ import annotations
-
 from collections.abc import Iterable
 from datetime import UTC, datetime
 from typing import cast

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -6,8 +6,6 @@ tests can therefore be async, and should instead run coroutines by creating an
 event loop when needed.
 """
 
-from __future__ import annotations
-
 import asyncio
 from datetime import UTC, datetime, timedelta
 from pathlib import Path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,5 @@
 """Test fixtures for wobbly tests."""
 
-from __future__ import annotations
-
 from collections.abc import AsyncGenerator
 
 import pytest_asyncio

--- a/tests/handlers/admin_test.py
+++ b/tests/handlers/admin_test.py
@@ -1,7 +1,5 @@
 """Tests for Wobbly administrative API."""
 
-from __future__ import annotations
-
 from datetime import UTC, datetime, timedelta
 
 import pytest

--- a/tests/handlers/internal_test.py
+++ b/tests/handlers/internal_test.py
@@ -1,7 +1,5 @@
 """Tests for the wobbly.handlers.internal module and routes."""
 
-from __future__ import annotations
-
 import pytest
 from httpx import ASGITransport, AsyncClient
 from safir.database import create_database_engine, drop_database

--- a/tests/handlers/service_test.py
+++ b/tests/handlers/service_test.py
@@ -1,7 +1,5 @@
 """Tests for the service API to Wobbly."""
 
-from __future__ import annotations
-
 from datetime import UTC, datetime, timedelta
 from typing import Any, cast
 from unittest.mock import ANY

--- a/tests/schema_test.py
+++ b/tests/schema_test.py
@@ -1,7 +1,5 @@
 """Tests for the Wobbly database schema."""
 
-from __future__ import annotations
-
 import subprocess
 
 import pytest


### PR DESCRIPTION
Remove `from __future__ import annotations` from all files. This has been deprecated upstream and is slowly being phased out.